### PR TITLE
Graceful Shutdown for Cloud-Native Environments

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -141,7 +141,13 @@ export const start = async () => {
   const apiServerPromise = new Promise<void>(resolve => apiServer.listen(config.api.port, config.api.hostname, () => resolve()));
   const p2pServerPromise = new Promise<void>(resolve => p2pServer.listen(config.p2p.port, config.p2p.hostname, () => resolve()));
   await Promise.all([apiServerPromise, p2pServerPromise]);
-  log.info(`Data exchange running on http://${config.api.hostname}:${config.api.port} (API) and ` +
+  log.info(`FireFly Data Exchange running on http://${config.api.hostname}:${config.api.port} (API) and ` +
     `https://${config.p2p.hostname}:${config.p2p.port} (P2P) - log level "${utils.constants.LOG_LEVEL}"`);
 
+};
+
+export const stop = async () => {
+  // add any additional logic for ensuring clients and handlers are finished with their work before shutting down
+  log.info("FireFly Data Exchange is gracefully shutting down");
+  process.exit();
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@
 
 import express from 'express';
 import http from 'http';
-import https, { Server } from 'https';
+import https from 'https';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import WebSocket from 'ws';
@@ -36,7 +36,9 @@ const log = new Logger("app.ts");
 
 const swaggerDocument = YAML.load(path.join(__dirname, './swagger.yaml'));
 
-let p2pServer : Server
+let p2pServer : https.Server
+let apiServer : http.Server
+let wss : WebSocket.Server
 
 let delegatedWebSocket: WebSocket | undefined = undefined;
 
@@ -51,12 +53,12 @@ export const start = async () => {
   await initCert();
 
   const apiApp = express();
-  const apiServer = http.createServer(apiApp);
+  apiServer = http.createServer(apiApp);
 
   const p2pApp = express();
   p2pServer = https.createServer(genTLSContext(), p2pApp);
 
-  const wss = new WebSocket.Server({
+  wss = new WebSocket.Server({
     server: apiServer, verifyClient: (info, cb) => {
       if (config.api === undefined || info.req.headers['x-api-key'] === config.apiKey) {
         cb(true);
@@ -146,8 +148,23 @@ export const start = async () => {
 
 };
 
+const shutdownHandler = (resolve : (value: void | PromiseLike<void>) => void) => {
+  return (err: Error | undefined) => {
+    if (err === undefined) {
+      resolve();
+    } else {
+      log.error(`Failed to close server due to ${err}`);
+    }
+  };
+};
+
 export const stop = async () => {
   // add any additional logic for ensuring clients and handlers are finished with their work before shutting down
-  log.info("FireFly Data Exchange is gracefully shutting down");
+  log.info("FireFly Data Exchange is gracefully shutting down the webservers");
+  const apiServerPromise = new Promise<void>(resolve => apiServer.close( shutdownHandler(resolve)));
+  const p2pServerPromise = new Promise<void>(resolve => p2pServer.close( shutdownHandler(resolve)));
+  const wssPromise = new Promise<void>(resolve => wss.close(shutdownHandler(resolve)));
+  await Promise.all([apiServerPromise, p2pServerPromise, wssPromise]);
+  log.info("FireFly Data Exchange has stopped all webservers, exiting");
   process.exit();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { start } from './app';
+import { start, stop } from './app';
 import { Logger } from './lib/logger';
 
 const log = new Logger("index.ts")
 
+process.on('SIGINT', stop);
+process.on('SIGTERM', stop);
+process.on('SIGQUIT', stop);
+
 start().catch(err => {
-  log.error(`Failed to FireFly Data Exchange ${err}`);
+  log.error(`Failed to start FireFly Data Exchange ${err}`);
 });


### PR DESCRIPTION
While running DX on K8s as part of https://github.com/hyperledger-labs/firefly/pull/114 I noticed pods would take the entire grace period before properly shutting down. Handling `INT` and `QUIT` will make it so we properly shut down when K8s terminates a pod (rather than using a CLI tool like `dumb-init`):

Output from testing:

First terminal where I ran DX
```shell
❯ npm start

> firefly-dataexchange@1.0.0 start
> node build/index.js

2021-07-02T15:22:32.819Z [INFO ]: FireFly Data Exchange running on http://0.0.0.0:3000 (API) and https://0.0.0.0:3001 (P2P) - log level "info" app.ts
2021-07-02T15:22:52.525Z [INFO ]: FireFly Data Exchange is gracefully shutting down app.ts
❯ npm start

> firefly-dataexchange@1.0.0 start
> node build/index.js

2021-07-02T15:22:59.358Z [INFO ]: FireFly Data Exchange running on http://0.0.0.0:3000 (API) and https://0.0.0.0:3001 (P2P) - log level "info" app.ts
2021-07-02T15:23:10.018Z [INFO ]: FireFly Data Exchange is gracefully shutting down app.ts
❯ npm start

> firefly-dataexchange@1.0.0 start
> node build/index.js

2021-07-02T15:23:17.321Z [INFO ]: FireFly Data Exchange running on http://0.0.0.0:3000 (API) and https://0.0.0.0:3001 (P2P) - log level "info" app.ts
2021-07-02T15:23:35.168Z [INFO ]: FireFly Data Exchange is gracefully shutting down app.ts
```

And terminal where I killed DX:
```
❯ ps aux | grep node
hfuss            16607   0.0  0.3  4767956  55500 s002  S+   11:22AM   0:00.61 node build/index.js
❯ kill -s QUIT 16607
❯ ps aux | grep node
hfuss            16612   0.0  0.3  4730180  57820 s002  S+   11:22AM   0:00.51 node build/index.js
❯ kill -s QUIT 16612
❯ ps aux | grep node
hfuss            16616   0.1  0.3  4785220  57936 s002  S+   11:23AM   0:00.57 node build/index.js
❯ kill -s TERM 16616
```

Will defer to @gabriel-indik @peterbroadhurst if any additional shutdown logic should be added to `stop` i.e. wait for all in-flight HTTP requests to finish, writing to disk operations, etc.