### PR TITLE
Decoupling Peers from config.json

### DIFF
--- a/src/lib/cert.ts
+++ b/src/lib/cert.ts
@@ -41,7 +41,7 @@ export const loadCAs = async () => {
   log.debug(`Reading peer CAs from ${peerCertsPath}`);
   const peerCerts = await fs.readdir(peerCertsPath);
   for(const peerCert of peerCerts) {
-    if (peerCert.endsWith(".pem")) {
+    if (peerCert.toLowerCase().endsWith(".pem")) {
       log.debug(`Reading peer CA ${peerCert}`);
       ca.push((await fs.readFile(path.join(peerCertsPath, peerCert))).toString());
     } else {

--- a/src/lib/cert.ts
+++ b/src/lib/cert.ts
@@ -27,7 +27,9 @@ export let ca: string[] = [];
 export let peerID: string;
 
 export const init = async () => {
+  log.debug("Reading key file");
   key = (await fs.readFile(path.join(utils.constants.DATA_DIRECTORY, utils.constants.KEY_FILE))).toString();
+  log.debug("Reading cert file");
   cert = (await fs.readFile(path.join(utils.constants.DATA_DIRECTORY, utils.constants.CERT_FILE))).toString();
   const certData = utils.getCertData(cert);
   peerID = utils.getPeerID(certData.organization, certData.organizationUnit);
@@ -36,9 +38,15 @@ export const init = async () => {
 
 export const loadCAs = async () => {
   const peerCertsPath = path.join(utils.constants.DATA_DIRECTORY, utils.constants.PEER_CERTS_SUBDIRECTORY);
+  log.debug(`Reading peer CAs from ${peerCertsPath}`);
   const peerCerts = await fs.readdir(peerCertsPath);
   for(const peerCert of peerCerts) {
-    ca.push((await fs.readFile(path.join(peerCertsPath, peerCert))).toString());
+    if (peerCert.endsWith(".pem")) {
+      log.debug(`Reading peer CA ${peerCert}`);
+      ca.push((await fs.readFile(path.join(peerCertsPath, peerCert))).toString());
+    } else {
+      log.warn(`Ignoring non-PEM extension file or directory ${peerCert} when loading CAs`);
+    }
   }
   log.debug(`Loaded ${ca.length} peer certificate(s)`);
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,6 +20,9 @@ import configSchema from '../schemas/config.json';
 import * as utils from './utils';
 import { IConfig } from './interfaces';
 import path from 'path';
+import {Logger} from "./logger";
+
+const log = new Logger('lib/config.ts')
 
 const ajv = new Ajv();
 const validateConfig = ajv.compile(configSchema);
@@ -34,13 +37,16 @@ export const init = async () => {
 
 const loadConfig = async () => {
   try {
+    log.debug(`Reading config file ${configFilePath}`);
     const data = JSON.parse(await fs.readFile(configFilePath, 'utf8'));
     try {
+      log.debug(`Reading peers file ${peersFilePath}`);
       data.peers = JSON.parse(await fs.readFile(peersFilePath, 'utf8'));
     } catch (err) {
-      // if file does not exist, just set peers to empty list
+      // if file does not exist, just set peers to either the peers from config.json (if migrating from older version) or to an empty list
+      log.debug(`Error code when reading peers file ${err.code}`);
       if (err.code === 'ENOENT') {
-        data.peers = [];
+        data.peers = data.peers || [];
       } else {
         throw err;
       }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,6 +31,7 @@ export const constants = {
   METADATA_SUFFIX: '.metadata.json',
   RECEIVED_BLOBS_SUBDIRECTORY: 'received',
   CONFIG_FILE_NAME: 'config.json',
+  PEERS_FILE_NAME: 'peers/data.json',
   CERT_FILE: 'cert.pem',
   KEY_FILE: 'key.pem',
   CA_FILE: 'ca.pem',

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -23,7 +23,7 @@ import * as blobsHandler from '../handlers/blobs';
 import * as eventsHandler from '../handlers/events';
 import * as messagesHandler from '../handlers/messages';
 import { ca, cert, key, peerID } from '../lib/cert';
-import { config, persistConfig } from '../lib/config';
+import { config, persistPeers } from '../lib/config';
 import { IStatus } from '../lib/interfaces';
 import RequestError from '../lib/request-error';
 import * as utils from '../lib/utils';
@@ -98,7 +98,7 @@ router.put('/peers/:id', async (req, res, next) => {
       };
       config.peers.push(peer);
     }
-    await persistConfig();
+    await persistPeers();
     await refreshCACerts();
     res.send({ status: 'added' });
   } catch (err) {
@@ -119,7 +119,7 @@ router.delete('/peers/:id', async (req, res, next) => {
       }
     }
     config.peers = config.peers.filter(peer => peer.id !== req.params.id);
-    await persistConfig();
+    await persistPeers();
     res.send({ status: 'removed' });
   } catch (err) {
     next(err);


### PR DESCRIPTION
While working on https://github.com/hyperledger-labs/firefly/pull/114, I understood `config.json` needs to be writeable solely for the sake of the `peers`. To me this indicated a difference between config (provided at start time and only changeable on restart) vs data (dynamic during runtime, does not require restart). Talking w/ @gabriel-indik confirmed this was a result of how DX has evolved over time.

While we could have it so that DX has init containers to copy over an initial config provided from a `Secret` to a writeable location, we get into challenges around detecting if config like `apiKey` or `p2p.endpoint` changes and having to reconcile the K8s/cloud provided config w/ the live, writeable config.

It felt easier to do some of the work now, and make `peers` a separate, writeable JSON file and have the two pieces of data get merged at load time. Additionally, if the `peers/data.json` does not exist it just sets the peers list to empty to avoid additional bootstrapping (though the subdirectory does have to be made...).

I'm wondering if `config.json`, `key.pem`, `cert.pem`, and `ca.pem` shouldn't be in an entirely separate separate folder i.e. /config so that the two directories can be have different permissions i.e. readable vs writeable. Looking for feedback there as opposed to having peers/data.json be a subfolder.

Also includes a bug related to reading CAs from EBS-backed PVCs, see https://github.com/hyperledger-labs/firefly-dataexchange-https/pull/28#issuecomment-875219742