### PR TITLE
Bug Fix and Other Enhancements to CA Support for mTLS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ import YAML from 'yamljs';
 import { eventEmitter as blobsEventEmitter } from './handlers/blobs';
 import * as eventsHandler from './handlers/events';
 import { eventEmitter as messagesEventEmitter } from './handlers/messages';
-import { genTLSContext, init as initCert, loadCAs } from './lib/cert';
+import { genTLSContext, init as initCert, loadPeerCAs } from './lib/cert';
 import { config, init as initConfig } from './lib/config';
 import { Logger } from './lib/logger';
 import RequestError, { errorHandler } from './lib/request-error';
@@ -43,7 +43,7 @@ let wss : WebSocket.Server
 let delegatedWebSocket: WebSocket | undefined = undefined;
 
 export const refreshCACerts = async () => {
-  await loadCAs()
+  await loadPeerCAs()
   p2pServer.setSecureContext(genTLSContext())
 };
 setRefreshCACerts(refreshCACerts)

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -23,15 +23,9 @@ declare global {
         [s: string]: string,
         0: string,
       },
-      client: {
-        authorized: boolean
-        getCertificate: () => {
-          issuer: {
-            O: string
-          }
-        },
+      socket: {
         getPeerCertificate: () => {
-          issuer: {
+          subject: {
             O: string
             OU: string
           }

--- a/src/lib/cert.ts
+++ b/src/lib/cert.ts
@@ -34,22 +34,20 @@ export const init = async () => {
   log.debug("Reading cert file");
   cert = (await fs.readFile(path.join(utils.constants.DATA_DIRECTORY, utils.constants.CERT_FILE))).toString();
 
-  log.debug("Loaded cert");
-  log.debug(cert);
-
-  log.debug("Deriving peer ID from cert");
-  const certData = utils.getCertData(cert);
-  peerID = utils.getPeerID(certData.organization, certData.organizationUnit);
-
   let caCertPath = path.join(utils.constants.DATA_DIRECTORY, utils.constants.CA_FILE);
   if (await utils.fileExists(caCertPath)) {
     log.debug("Reading CA file");
     certBundle = (await fs.readFile(caCertPath)).toString() + cert;
     log.debug("Loaded CA + cert");
-    log.debug(certBundle);
   } else {
     certBundle = cert;
+    log.debug("Loaded cert");
   }
+  log.debug("\n" + certBundle);
+
+  log.debug("Deriving peer ID from cert");
+  const certData = utils.getCertData(cert);
+  peerID = utils.getPeerID(certData.organization, certData.organizationUnit);
 
   await loadPeerCAs();
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,6 +22,7 @@ import { X509 } from 'jsrsasign';
 import { ICertData, IFile } from './interfaces';
 import { Logger } from './logger';
 import RequestError from './request-error';
+import { TLSSocket } from "tls";
 
 export const constants = {
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',
@@ -149,4 +150,9 @@ export const getCertData = (cert: string): ICertData => {
     certData.organizationUnit = ou[1];
   }
   return certData;
+};
+
+export const extractPeerSenderFromRequest = (req: Request): string => {
+  const cert = ((req.socket) as TLSSocket).getPeerCertificate();
+  return getPeerID(cert.subject.O, cert.subject.OU);
 };

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -22,7 +22,7 @@ import { v4 as uuidV4 } from 'uuid';
 import * as blobsHandler from '../handlers/blobs';
 import * as eventsHandler from '../handlers/events';
 import * as messagesHandler from '../handlers/messages';
-import { ca, cert, key, peerID } from '../lib/cert';
+import { ca, cert, certBundle, key, peerID } from '../lib/cert';
 import { config, persistPeers } from '../lib/config';
 import { IStatus } from '../lib/interfaces';
 import RequestError from '../lib/request-error';
@@ -41,7 +41,7 @@ router.get('/id', async (_req, res, next) => {
     res.send({
       id: peerID,
       endpoint: config.p2p.endpoint ?? `https://${config.p2p.hostname}:${config.p2p.port}`,
-      cert 
+      cert: certBundle
     });
   } catch (err) {
     next(err);

--- a/src/routers/p2p.ts
+++ b/src/routers/p2p.ts
@@ -31,8 +31,7 @@ router.head('/ping', (_req, res) => {
 
 router.post('/messages', async (req: Request, res, next) => {
   try {
-    const cert = req.client.getPeerCertificate();
-    const sender = utils.getPeerID(cert.issuer.O, cert.issuer.OU);
+    const sender = utils.extractPeerSenderFromRequest(req);
     const message = await utils.extractMessageFromMultipartForm(req);
     eventEmitter.emit('event', {
       id: uuidV4(),
@@ -48,8 +47,7 @@ router.post('/messages', async (req: Request, res, next) => {
 
 router.put('/blobs/*', async (req: Request, res, next) => {
   try {
-    const cert = req.client.getPeerCertificate();
-    const sender = utils.getPeerID(cert.issuer.O, cert.issuer.OU);
+    const sender = utils.extractPeerSenderFromRequest(req);
     const file = await utils.extractFileFromMultipartForm(req);
     const blobPath = path.join(utils.constants.RECEIVED_BLOBS_SUBDIRECTORY, sender, req.params[0]);
     const metadata = await blobsHandler.storeBlob(file, blobPath);


### PR DESCRIPTION
## Fixes

Originally p2p APIs were using `req.client.getPeerCertificate().issuer` to determine the ID of the DX which sent the request. This worked for self-signed certificates because the `issuer == subject`, however for CA-signed certs provisioned w/ cert-manger, or internal Kaleido certs signed with a environment's CA, the `issuer != subject` and it was causing issues with private messaging E2E tests in those environments. `subject` should be used because DX uses it to derive its own peer ID that it advertises on `GET /id`.

For example, w/ a cert-manager cert signed by a CA (the CA happened to not have an O or OU) the DX would get the following error when trying to hit another org's DX:

```
2021-07-14T16:54:18.679Z [ERROR]: post https://a-firefly-host/api/v1/messages attempt 0 [500] { error: 'Invalid peer' } utils.ts
```

By casting the socket of the req to the `TLSSocket` it allows Typescript to then retrieve the `subject` from the peer's certificate which is what should be used to derive the DX's ID from the O and OU.

## Additions

With cert-manager certificates, the `cert.pem` does not include the CA which signed it. If the CA is self-signed, this needs to be advertised in `GET /id` so peers can include the CA in their `HttpsAgent` and when they persist the certs in the `peer-certs` directory.

This adds support to _optionally_ (if the file exists) read a `ca.pem` file from the `DATA_DIRECTORY` (same directory as `key.pem` and `cert.pem`) and prepend it the `cert.pem` storing it in a new var `certBundle`. `certBundle` is then returned on `GET /id` so peers will receive both the cert and the provided CA. The `cert` var is left to only contain the `cert.pem` because including the CA seemed to break the server startup when used in the `TLSContext`.

While self-signed CAs were already supported by putting a `ca.pem` in the `peer-certs` directory before startup (as what was is currently documented in the README) this _allows peers to have certs signed by separate CAs_ w/o every peer needing to be aware of them on startup. It also allows new DX peers to join the network with renewed CA certs.

## Original Issue

These changes arose from issues we found w/ FF DX deployments using self-signed CAs where the NodeJS HTTPS agent couldn't trust the cert from a peer bc the CA wasn't included in the chain (in a lot of ways this was just a config issue):

```
2021-07-14T15:23:19.854Z [ERROR]: post https://a-firefly-host/api/v1/messages attempt 2 [undefined] Error: unable to verify the first certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1514:34)
    at TLSSocket.emit (events.js:375:28)
    at TLSSocket._finishInit (_tls_wrap.js:936:8)
    at TLSWrap.ssl.onhandshakedone
```

However, in Kubernetes environments where `peer-certs` is backed by a PVC, the `ca.pem` cannot be included into the directory before startup without init/bootstrap scripts (for example see the [Helm chart PR in firefly](https://github.com/hyperledger-labs/firefly/pull/114/files#diff-abf2c3ec729c16f0ff294d8b85ac9fa0c5a747bc602839b95fd4040466f829b5R68-R84)). Upon adding the `ca.pem` / `certBundle` feature the bug above around the `subject` of the peer certificate was then discovered and needed to be fixed.