### PR TITLE
Fix CODEOWNERS group name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# firefly-cli maintainers
+# firefly-dataexchange-https maintainers
 * @gabriel-indik @peterbroadhurst


### PR DESCRIPTION
Signed-off-by: Nicko Guyer <nicko.guyer@kaleido.io>