### PR TITLE
Update tsconfig to ignore test

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": [ "src" ],
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",


### PR DESCRIPTION
Frustratingly `npm t` didn't see this on the PR build for #46, but we hit it in the docker build:

```
> firefly-dataexchange@1.0.0 clean /firefly-dataexchange-https
> rimraf ./build

error TS6059: File '/firefly-dataexchange-https/test/app.test.ts' is not under 'rootDir' '/firefly-dataexchange-https/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in '/firefly-dataexchange-https/tsconfig.json'
```

https://github.com/hyperledger/firefly-dataexchange-https/runs/4001792961?check_suite_focus=true